### PR TITLE
Coalesce gifted subs

### DIFF
--- a/stream/api_twitch.py
+++ b/stream/api_twitch.py
@@ -97,28 +97,38 @@ class APItwitch(APIbase):
                             )
         return
 
+    # Mapping of known sub plans to plain-English names
+    _sub_types = {
+        "1000": "tier one",
+        "2000": "tier two",
+        "3000": "tier three",
+        "Prime": "prime"
+    }
+
+    def _get_sub_type(self, sub_plan: str):
+        """Returns a plain-English version of sub plan level if available."""
+
+        return APItwitch._sub_types.get(sub_plan, "")
 
     async def callback_subs(self, uuid: UUID, data: dict):
         """Subscription handler"""
         self.log("callback_subs",json.dumps(data))
 
         # Get plain english version of sub level
-        sub_type=""
-        if (str(data['sub_plan']) == "1000"):
-            sub_type="tier one"
-        if (str(data['sub_plan']) == "2000"):
-            sub_type="tier two"
-        if (str(data['sub_plan']) == "3000"):
-            sub_type="tier three"
-        if (str(data['sub_plan']) == "Prime"):
-            sub_type="prime"
+        sub_type = self._get_sub_type(str(data['sub_plan']))
 
         # Determine length of sub
+        sub_months=1
         sub_len=""
+
         if ('benefit_end_month' in data and data['benefit_end_month'] != 0):
-            sub_len="for "+str(int(data['benefit_end_month'])+1)+" months"
+            sub_months = int(data['benefit_end_month']) + 1
+
         if ('multi_month_duration' in data and data['multi_month_duration'] > 1):
-            sub_len="for "+str(data['multi_month_duration'])+" months"
+            sub_months = int(data['multi_month_duration'])
+
+        if sub_months > 1:
+            sub_len = "for " + str(sub_months) + " months"
 
         # Sub type and build output message
         line=""
@@ -137,4 +147,3 @@ class APItwitch(APIbase):
                             line
                             )
         return
-

--- a/test_coalescer.py
+++ b/test_coalescer.py
@@ -1,0 +1,66 @@
+import asyncio
+from utils.coalescer import EventCoalescer
+
+# Some tests to make sure the event coalescer is doing roughly the right thing!
+#
+# Ideally I'd use a test framework for this but I'm not sure if Shelby has
+# a preferred one, so even a simple command-line test is better than nothing.
+async def main():
+    """Very basic test routine that I should probably use a framework for."""
+
+    print("""Now performing some simple tests of the EventCoalescer class.
+
+The first test should add five items, one every 0.1 seconds, and display them
+two seconds after the last item is added.
+
+The second test will start a second afterwards and will add three items, with a
+second's delay between each one; again, it should display the results two
+seconds after the last item is added.
+
+The tests will be preceded by a five-second pause during which no events should
+fire.\n""")
+
+    start_time = asyncio.get_running_loop().time()
+
+    def print_with_time(msg):
+        current_time = asyncio.get_running_loop().time()
+        delta_time = current_time - start_time
+
+        print(f"{delta_time:0.6f} sec: {msg}")
+
+    async def list_callback(context, items):
+        """Test callback"""
+
+        print_with_time(f"Got a list of items in context '{context}': " +
+                        ", ".join(items))
+
+    coalescer = EventCoalescer(2, "test", list_callback)
+
+    def add_test_event(n):
+        name = f"Event {n+1}"
+        print_with_time(f"Adding {name}")
+        coalescer.add_event(name)
+
+    await asyncio.sleep(5)
+
+    for n in range(5):
+        add_test_event(n)
+        await asyncio.sleep(0.1)
+
+    await asyncio.sleep(3)
+
+    for n in range(5, 8):
+        add_test_event(n)
+        await asyncio.sleep(1)
+
+    await asyncio.sleep(5)
+
+
+if __name__ == "__main__":
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(main())
+    finally:
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()

--- a/utils/coalescer.py
+++ b/utils/coalescer.py
@@ -1,0 +1,42 @@
+from utils.restartable_timeout import RestartableTimeout
+
+class EventCoalescer(RestartableTimeout):
+    """Gather together individual events until a specified period of inactivity.
+    
+    This class maintains a list of incoming event objects, and then fires
+    a callback once no new items have been added within a configurable
+    timeout period.  The callback is passed a context object, to allow for
+    multiple EventCoalescers to share one callback, along with a list of
+    the individual event items that have been added since the callback was
+    last triggered."""
+
+    def __init__(self, timeout, context, callback):
+        """Construct a new EventCoalescer with context and timeout.
+        
+        Parameters:
+            timeout     inactivity timeout, in seconds
+            context     an arbitrary object, passed to the callback when fired
+            callback    callback to fire when the timeout expires
+        """
+        RestartableTimeout.__init__(self, timeout, self._inner_callback)
+        self._list_callback = callback
+        self._context = context
+        self._list = []
+
+    async def _inner_callback(self):
+        """Called by RestartableTimeout after the inactivity timer expires."""
+
+        # Take a copy of the current list of events and then clear it, so that
+        # we don't end up losing any events if the callback causes any new ones
+        # to be added!
+        events = self._list
+        self._list = []
+
+        # Fire our own callback, passing our context and list of new events
+        if len(events) > 0:
+            await self._list_callback(self._context, events)
+
+    def add_event(self, event):
+        """Add an event to the list that will eventually be reported."""
+        self._list.append(event)
+        self.restart()

--- a/utils/restartable_timeout.py
+++ b/utils/restartable_timeout.py
@@ -1,0 +1,44 @@
+import asyncio
+
+class RestartableTimeout:
+    """Simple utility class to implement a restartable async timeout.
+
+    Each instance of this class represents a single timeout, and will fire a
+    callback once after a specified interval.  The timeout can be restarted
+    at any time, at which point it is rescheduled for the same interval in the
+    future; if it has not yet fired the original scheduled callback will be
+    cancelled.
+    
+    Based on Mikhail Gerasimov's example async timer code from 
+    https://stackoverflow.com/a/45430833."""
+
+    def __init__(self, timeout, callback):
+        """Starts a new async timeout.
+        
+        Parameters:
+            timeout     timeout duration, in seconds
+            callback    async routine to call when the timeout expires
+        """
+
+        self._timeout = timeout
+        self._callback = callback
+        self._task = asyncio.ensure_future(self._job())
+
+    async def _job(self):
+        await asyncio.sleep(self._timeout)
+        await self._callback()
+
+    def cancel(self):
+        """Cancel any outstanding timeout."""
+
+        self._task.cancel()
+
+    def restart(self):
+        """Restart (extend) the timeout period.
+        
+        If the callback has not yet fired, it will be rescheduled to do so
+        after the originally-specified timeout interval.  If it has already
+        fired, it will fire again after that same timeout."""
+
+        self.cancel()
+        self._task = asyncio.ensure_future(self._job())


### PR DESCRIPTION
An attempt to coalesce groups of gifted subs (all from the same user, of the same type and duration) into single events that can be read out less disruptively, etc.

This PR is made up of four commits, which can in theory be applied individually to make sure I've not messed anything up:
1. some very light refactoring to pull out some code from `callback_subs` that we'll need to call from the new grouped-gifted-sub formatter
2. some heavier refactoring to route all gifted subs through a new (stubbed-out) intermediary routine (`_coalesce_gifted_subs`) and a callback that can handle multiple recipients at one (`callback_gifted_sub_list`)
3. add utility classes that implement a restartable timeout (based on Mikhail Gerasimov's example async timer code from 
    https://stackoverflow.com/a/45430833) and a coalescing event queue, `EventCoalescer`
4. finally, use `EventCoalescer` to, well, coalesce the events

Unfortunately I haven't been able to actually run the Twitch code to test this out, but there is a `test_coalescer.py` script that performs some simple tests of the `EventCoalescer` class to make sure it's behaving as I wanted it to - hopefully the structure of these commits should allow for relatively straightforward testing and/or bisecting if the Twitch side of things turns out not to work as expected.